### PR TITLE
Add ApiCall

### DIFF
--- a/app/src/main/java/com/example/simpsons/core/api/ApiCall.kt
+++ b/app/src/main/java/com/example/simpsons/core/api/ApiCall.kt
@@ -1,0 +1,32 @@
+package com.example.simpsons.core.api
+
+import android.util.Log
+import com.example.simpsons.core.errors.ErrorApp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.Response
+import java.io.IOException
+
+suspend fun <T> apiCall(
+    call: suspend () -> Response<T>
+): Result<T> {
+    return withContext(Dispatchers.IO) {
+        runCatching {
+            val response = call()
+            Log.d("API_CALL", "Response code: ${response.code()}")
+
+            if (response.isSuccessful && response.body() != null) {
+                Result.success(response.body()!!)
+            } else {
+                Log.e("API_CALL", "Server error: ${response.code()}")
+                Result.failure(ErrorApp.ServerErrorApp)
+            }
+        }.getOrElse { exception ->
+            Log.e("API_CALL", "Exception: ${exception.message}")
+            when (exception) {
+                is IOException -> Result.failure(ErrorApp.InternetConexionError)
+                else -> Result.failure(ErrorApp.ServerErrorApp)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/simpsons/features/data/remote/api/SimpsonsApiRemoteDataSource.kt
+++ b/app/src/main/java/com/example/simpsons/features/data/remote/api/SimpsonsApiRemoteDataSource.kt
@@ -1,52 +1,23 @@
 package com.example.simpsons.features.data.remote.api
 
-import android.util.Log
 import com.example.simpsons.core.api.ApiClient
-import com.example.simpsons.core.errors.ErrorApp
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import com.example.simpsons.core.api.apiCall
 import org.koin.core.annotation.Single
 
 @Single
 class SimpsonsApiRemoteDataSource(private val apiClient: ApiClient) {
 
+    private val apiService: SimpsonsApiService by lazy {
+        apiClient.createService(SimpsonsApiService::class.java)
+    }
+
     suspend fun getSimpsons(): Result<List<SimpsonsApiModel>> {
-        return withContext(Dispatchers.IO) {
-            Log.d("API_DEBUG", "=== INICIO PETICIÓN ===")
-            Log.d("API_DEBUG", "Thread: ${Thread.currentThread().name}")
-
-            val apiService = apiClient.createService(SimpsonsApiService::class.java)
-            Log.d("API_DEBUG", "ApiService creado")
-
-            val response = apiService.findAll()
-            Log.d("API_DEBUG", "Response code: ${response.code()}")
-            Log.d("API_DEBUG", "Response message: ${response.message()}")
-
-            if (response.isSuccessful) {
-                val characters = response.body()!!.results
-
-                Log.d("API_DEBUG", "ÉXITO: ${characters.size} personajes")
-                Result.success(characters)
-            } else {
-                Log.e("API_DEBUG", "Error servidor: ${response.code()}")
-                Result.failure(ErrorApp.ServerErrorApp)
-            }
+        return apiCall { apiService.findAll() }.map { response ->
+            response.results
         }
     }
 
     suspend fun getSimpsonById(id: String): Result<SimpsonsApiModel> {
-        return withContext(Dispatchers.IO) {
-            Log.d("API_DEBUG", "Buscando Simpson ID: $id")
-            val apiService = apiClient.createService(SimpsonsApiService::class.java)
-            val response = apiService.findById(id)
-
-            if (response.isSuccessful && response.body() != null) {
-                Log.d("API_DEBUG", "Simpson encontrado: ${response.body()!!.name}")
-                Result.success(response.body()!!)
-            } else {
-                Log.e("API_DEBUG", "Error: ${response.code()}")
-                Result.failure(ErrorApp.ServerErrorApp)
-            }
-        }
+        return apiCall { apiService.findById(id) }
     }
 }


### PR DESCRIPTION
name: Añadir apiCall como recurso compartido
title: "[Feature]: Añadir apiCall como recurso compartido"
labels: ["feature"]
projects: ["Simpsons-API"]
assignees: danilop418
---
## 🤔 Breve descripción del problema a resolver
La lógica de llamadas a la API y el manejo de errores se encontraba duplicada y dispersa, dificultando el mantenimiento y la reutilización del código.

## 💡 Proceso seguido para resolver el problema
- Revisión de la arquitectura actual del proyecto  
- Análisis de duplicidades en llamadas Retrofit  
- Consulta de la documentación oficial de Retrofit y Coroutines  
- Revisión de buenas prácticas de manejo de errores  
- Apoyo con Inteligencia Artificial (Grok)(Claude)(Kimi)(DeepSeek)(DeepWiki)

## 👩‍💻 Resumen técnico de la Solución

**Pasos lógicos:**
1. Crear una función genérica `apiCall` para encapsular peticiones HTTP.
2. Centralizar el manejo de errores de red y servidor.
3. Refactorizar los data sources remotos para usar `apiCall`.
4. Optimizar la creación del servicio Retrofit usando inicialización lazy.

## 📸 Screenshot o Video

*(No aplica para esta PR)*

## ✋ Notas adicionales (Disclaimer)
- No se ha modificado la lógica de negocio.
- Se ha mantenido la compatibilidad con la arquitectura existente.

## 🌈 GIF representativo de esta PR
![🚀 API calls optimizadas](https://media.giphy.com/media/26ufdipQqU2lhNA4g/giphy.gif)
*(¡Llamadas a la API más limpias y reutilizables! ✨)*

## ✅ Checklist
- [x] La rama tiene el formato correcto: `feature/XX-refactor-codigo`
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [x] He asignado a dos revisores.
- [x] He relacionado la PR con la Issue.

### Commits realizados
- Se introduce una función genérica `apiCall` para encapsular la lógica de peticiones y el manejo de errores.
- Se refactoriza el `SimpsonsApiRemoteDataSource` para usar la nueva función `apiCall`.
- Se optimiza la creación de la instancia de `SimpsonsApiService` para que sea perezosa (lazy).
