### PR TITLE
Fix images

### DIFF
--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -10,88 +10,140 @@
         android:id="@+id/detailContent"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:fillViewport="true"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toBottomOf="parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:orientation="vertical"
             android:padding="16dp">
 
-            <androidx.cardview.widget.CardView
-                android:id="@+id/imageCard"
-                android:layout_width="0dp"
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:cardCornerRadius="16dp"
-                app:cardElevation="8dp"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent">
+                app:cardCornerRadius="12dp"
+                app:cardElevation="1dp"
+                app:cardBackgroundColor="@color/md_theme_surfaceContainerLowest">
 
-                <ImageView
-                    android:id="@+id/simpsonImage"
+                <LinearLayout
                     android:layout_width="match_parent"
-                    android:layout_height="300dp"
-                    android:scaleType="centerCrop"
-                    android:contentDescription="@string/simpson_detail_image"
-                    tools:src="@tools:sample/avatars"/>
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
 
-            </androidx.cardview.widget.CardView>
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:padding="16dp">
 
-            <TextView
-                android:textColor="@color/md_theme_tertiary"
-                android:textSize="25sp"
-                android:textStyle="bold"
-                android:id="@+id/nameLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="24dp"
-                android:fontFamily="@font/simpsons_font"
-                android:text="@string/detail_name_label"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/imageCard" />
+                        <ImageView
+                            android:id="@+id/headerAvatar"
+                            android:layout_width="40dp"
+                            android:layout_height="40dp"
+                            android:background="@drawable/circle_primary"
+                            android:scaleType="fitCenter"
+                            android:contentDescription="@string/simpson_detail_image"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            tools:src="@tools:sample/avatars"/>
 
-            <TextView
-                android:id="@+id/simpsonName"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:textColor="@color/md_theme_onSurface"
-                android:textSize="20sp"
-                app:layout_constraintBaseline_toBaselineOf="@id/nameLabel"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/nameLabel"
-                tools:text="Homer Simpson" />
+                        <TextView
+                            android:id="@+id/headerTitle"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="16dp"
+                            android:text="@string/app_name"
+                            android:textColor="@color/md_theme_onSurface"
+                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            app:layout_constraintStart_toEndOf="@id/headerAvatar"
+                            app:layout_constraintTop_toTopOf="@id/headerAvatar"
+                            app:layout_constraintEnd_toEndOf="parent"/>
 
-            <TextView
-                android:textColor="@color/md_theme_tertiary"
-                android:textSize="25sp"
-                android:textStyle="bold"
-                android:id="@+id/phraseLabel"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:fontFamily="@font/simpsons_font"
-                android:text="@string/detail_phrase_label"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/nameLabel" />
+                        <TextView
+                            android:id="@+id/headerSubtitle"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="16dp"
+                            android:text="@string/simpson_detail_details_title"
+                            android:textColor="@color/md_theme_onSurfaceVariant"
+                            android:textSize="14sp"
+                            app:layout_constraintStart_toEndOf="@id/headerAvatar"
+                            app:layout_constraintTop_toBottomOf="@id/headerTitle"
+                            app:layout_constraintEnd_toEndOf="parent"/>
 
-            <TextView
-                android:id="@+id/simpsonPhrase"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:textColor="@color/md_theme_onSurface"
-                android:textSize="20sp"
-                android:textStyle="italic"
-                app:layout_constraintBaseline_toBaselineOf="@id/phraseLabel"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/phraseLabel"
-                tools:text="D'oh!" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                    <ImageView
+                        android:id="@+id/simpsonImage"
+                        android:layout_width="match_parent"
+                        android:layout_height="200dp"
+                        android:scaleType="fitCenter"
+                        android:background="@color/md_theme_surfaceContainerHigh"
+                        android:contentDescription="@string/simpson_detail_image"
+                        tools:src="@tools:sample/backgrounds/scenic"/>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:padding="16dp">
+
+                        <TextView
+                            android:id="@+id/simpsonName"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/md_theme_onSurface"
+                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            tools:text="Homer Simpson" />
+
+                        <TextView
+                            android:id="@+id/phraseLabel"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/simpson_detail_phrase_title"
+                            android:textColor="@color/md_theme_onSurfaceVariant"
+                            android:textSize="14sp" />
+
+                        <TextView
+                            android:id="@+id/simpsonPhrase"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="16dp"
+                            android:textColor="@color/md_theme_onSurfaceVariant"
+                            android:textSize="14sp"
+                            android:lineSpacingMultiplier="1.4"
+                            tools:text="D'oh! Why do I always have to be the one to say something stupid?" />
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="16dp"
+                            android:gravity="end"
+                            android:orientation="horizontal">
+
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/buttonBack"
+                                style="@style/Widget.Material3.Button.OutlinedButton"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/back_button"/>
+
+                        </LinearLayout>
+
+                    </LinearLayout>
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+        </LinearLayout>
 
     </ScrollView>
 

--- a/app/src/main/res/layout/view_simpsons_item.xml
+++ b/app/src/main/res/layout/view_simpsons_item.xml
@@ -22,7 +22,7 @@
             android:id="@+id/avatar"
             android:layout_width="56dp"
             android:layout_height="56dp"
-            android:scaleType="centerCrop"
+            android:scaleType="fitCenter"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
name: Corregir visualización de imágenes
title: "[Fix]: Corregir visualización de imágenes"
labels: ["bug"]
projects: ["Simpsons-API"]
assignees: danilop418

---

## 🤔 Breve descripción del problema a resolver
Las imágenes de los personajes no se mostraban correctamente debido a un uso incorrecto de los modos `fitCenter` y `centerInside`, provocando recortes o escalados no deseados.

## 💡 Proceso seguido para resolver el problema
- Análisis del comportamiento de escalado de imágenes  
- Revisión de los atributos `scaleType` en los layouts  
- Ajuste de la configuración de imágenes para una correcta visualización  
- Pruebas en distintos tamaños de pantalla  
- Apoyo con Inteligencia Artificial (Grok)(Claude)(Kimi)(DeepSeek)(DeepWiki)

## 👩‍💻 Resumen técnico de la Solución

**Pasos lógicos:**
1. Identificar el uso incorrecto de `fitCenter` y `centerInside`.
2. Ajustar el `scaleType` adecuado según el contexto.
3. Verificar que las imágenes se muestren sin deformaciones ni recortes.

## 📸 Screenshot o Video
*(No aplica para esta PR)*

## ✋ Notas adicionales (Disclaimer)
- El cambio es únicamente visual.
- No afecta a la lógica de negocio ni a la obtención de datos.

## 🌈 GIF representativo de esta PR
![AaronRodgersSmileGIF](https://github.com/user-attachments/assets/334182ac-21db-4090-a3d1-4eb443f6f7d5)

*(¡Imágenes bien ajustadas! ✨)*

## ✅ Checklist
- [x] La rama tiene el formato correcto: `fix/XX-image-scale`
- [x] He añadido un título a la PR descriptivo.
- [x] Me he asignado como autor.
- [x] He asignado a dos revisores.
- [x] He relacionado la PR con la Issue correspondiente.

### Commits realizados
- Se arregla el error con las imágenes usando `fitCenter` y `centerInside`.
